### PR TITLE
PUB-1111 | Implementing logic to take user back to classic publish in sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 .vscode
+.idea

--- a/src/components/AppSidebar/index.jsx
+++ b/src/components/AppSidebar/index.jsx
@@ -39,6 +39,9 @@ const AppSidebar = ({
   environment,
   onMenuItemClick,
   onUpgradeToProClick,
+  onReturnToClassicClick,
+  isProUpgradeUser,
+  isAbleToReturnToClassicUser,
 }) => (
   <nav style={style} aria-label="sidebar" role="menubar">
     <BufferLogo />
@@ -100,11 +103,22 @@ const AppSidebar = ({
             >
               Preferences
             </PopoverMenuItem>
-            {activeProduct === 'publish' && (
-              <PopoverMenuItem href="#" onClick={onUpgradeToProClick}>
-                ★ Upgrade to Pro
-              </PopoverMenuItem>
-            )}
+            {activeProduct === 'publish' &&
+              isAbleToReturnToClassicUser && (
+                <PopoverMenuItem
+                  href="#"
+                  onClick={onReturnToClassicClick}
+                  highlight
+                >
+                  Back to Classic Design
+                </PopoverMenuItem>
+              )}
+            {activeProduct === 'publish' &&
+              isProUpgradeUser && (
+                <PopoverMenuItem href="#" onClick={onUpgradeToProClick}>
+                  ★ Upgrade to Pro
+                </PopoverMenuItem>
+              )}
             <Divider color="sidebarBackgroundBlue" />
             <PopoverMenuItem
               href={logoutUrl({
@@ -131,10 +145,16 @@ AppSidebar.propTypes = {
   environment: PropTypes.string.isRequired,
   onMenuItemClick: PropTypes.func.isRequired,
   onUpgradeToProClick: PropTypes.func.isRequired,
+  onReturnToClassicClick: PropTypes.func.isRequired,
+  isProUpgradeUser: PropTypes.bool,
+  isAbleToReturnToClassicUser: PropTypes.bool,
 }
 
 AppSidebar.defaultProps = {
   activeProduct: 'publish',
+  isProUpgradeUser: false,
+  isAbleToReturnToClassicUser: false,
+  onReturnToClassicClick: () => {},
 }
 
 export default AppSidebar

--- a/src/components/AppSidebar/story.jsx
+++ b/src/components/AppSidebar/story.jsx
@@ -29,3 +29,45 @@ storiesOf('AppSidebar', module)
       />
     </div>
   ))
+  .add('should show app sidebar with updgrade to Pro link', () => (
+    <div style={{ width: '65px', height: '100%', display: 'flex' }}>
+      <AppSidebar
+        activeProduct="publish"
+        translations={translations}
+        user={fakeUser}
+        environment={'production'}
+        onMenuItemClick={action('onMenuItemClick')}
+        onUpgradeToProClick={action('onUpgradeToProClick')}
+        isProUpgradeUser={true}
+      />
+    </div>
+  ))
+  .add('should show app sidebar with return to classic', () => (
+    <div style={{ width: '65px', height: '100%', display: 'flex' }}>
+      <AppSidebar
+        activeProduct="publish"
+        translations={translations}
+        user={fakeUser}
+        environment={'production'}
+        onMenuItemClick={action('onMenuItemClick')}
+        onUpgradeToProClick={action('onUpgradeToProClick')}
+        onReturnToClassicClick={action('onReturnToClassicClick')}
+        isAbleToReturnToClassicUser={true}
+      />
+    </div>
+  ))
+  .add('should show app sidebar with all things enabled', () => (
+    <div style={{ width: '65px', height: '100%', display: 'flex' }}>
+      <AppSidebar
+        activeProduct="publish"
+        translations={translations}
+        user={fakeUser}
+        environment={'production'}
+        onMenuItemClick={action('onMenuItemClick')}
+        onUpgradeToProClick={action('onUpgradeToProClick')}
+        onReturnToClassicClick={action('onReturnToClassicClick')}
+        isAbleToReturnToClassicUser={true}
+        isProUpgradeUser={true}
+      />
+    </div>
+  ))

--- a/src/components/PopoverMenuItem/index.jsx
+++ b/src/components/PopoverMenuItem/index.jsx
@@ -13,7 +13,7 @@ const handleOnClick = onClick => e => {
 
 class PopoverMenuItem extends PseudoClassComponent {
   render() {
-    const { href, children, subtitle, onClick } = this.props
+    const { href, children, subtitle, onClick, highlight } = this.props
     const mainLinkStyle = {
       display: 'block',
       color: '#fff',
@@ -40,12 +40,15 @@ class PopoverMenuItem extends PseudoClassComponent {
         hovered: this.state.hovered,
       },
     )
+    const listStyle = highlight ? { backgroundColor: '#1b2a3a' } : {}
+
     return (
       <li
         onMouseEnter={() => this.handleMouseEnter()}
         onMouseLeave={() => this.handleMouseLeave()}
         onFocus={() => this.handleFocus()}
         onBlur={() => this.handleBlur()}
+        style={listStyle}
       >
         {subtitle ? (
           <a
@@ -76,6 +79,11 @@ PopoverMenuItem.propTypes = {
   href: PropTypes.string,
   children: PropTypes.node,
   subtitle: PropTypes.node,
+  highlight: PropTypes.bool,
+}
+
+PopoverMenuItem.defaultProps = {
+  highlight: false,
 }
 
 export default PopoverMenuItem


### PR DESCRIPTION
Adding logic to display additional sidebar menu to return user to classic publish

![image](https://user-images.githubusercontent.com/1383419/52416135-cfde3d00-2ae0-11e9-937f-35ed8ae5753a.png)

This will get handled via the implementor, but the logic to display and not, is within the sidebar.
The logic of how to handle the action is a concern of the publish app, so this just hands over a function to trigger an action, and its upto publish to pass through that action trigger